### PR TITLE
Bug fix: limit grep in SSH config to 1 result

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -12,7 +12,7 @@ rmount() {
 	[[ ${1%:} == $ssh_name ]] && mount_folder='' || mount_folder=${1##*:}
 
 	# Get the ssh name in SSH config, if available
-	custom_folder=$(grep -i "host $ssh_name" ~/.ssh/config)
+	custom_folder=$(grep -i "host $ssh_name" -m1 ~/.ssh/config)
 
 	# If the ssh name is found in the SSH config
 	if [[ $custom_folder != '' ]]; then


### PR DESCRIPTION
Bug fix: limit grep in SSH config to 1 result to enable mounting folders starting with the same name.  For example, will no longer bug with "rmount main" when the following is in SSH config:

Host main
Host mainsite

Note that you must put the shorter name first in your SSH config.
