### PR TITLE
Capitalize REMOTE_ADDR in vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -61,7 +61,8 @@ augroup END
 
 
 " Commands
-command! IP :call ShowPhpIP()
+command! IP :call ShowPhpIP("O")
+command! Ip :call ShowPhpIP("o")
 command! Reload :so $MYVIMRC
 
 " Plugins
@@ -91,9 +92,9 @@ inoremap <Down> <NOP>
 inoremap <Left> <NOP>
 inoremap <Right> <NOP>
 
-function! ShowPhpIP(...)
+function! ShowPhpIP(position, ...)
   let ip = system('curl -s http://ipv4.myexternalip.com/raw | tr --delete "\n"')
-	:put ='if( $_SERVER[\"REMOTE_ADDR\"] == \"'.ip.'\" ) {'
+  execute "normal! ".a:position."if( $_SERVER[\"REMOTE_ADDR\"] == \"".ip."\" ) {"
 endfunction
 
 

--- a/.vimrc
+++ b/.vimrc
@@ -93,7 +93,7 @@ inoremap <Right> <NOP>
 
 function! ShowPhpIP(...)
   let ip = system('curl -s http://ipv4.myexternalip.com/raw | tr --delete "\n"')
-	:put ='if( $_SERVER[\"remote_addr\"] == \"'.ip.'\" ) {'
+	:put ='if( $_SERVER[\"REMOTE_ADDR\"] == \"'.ip.'\" ) {'
 endfunction
 
 


### PR DESCRIPTION
This seems to be necessary on some servers at least.